### PR TITLE
Porting files from es6 to es5.1 syntax.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 streams.lib.bundle.js
+es5.1/

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   },
   "homepage": "https://github.com/mukulmishra18/streams-lib#readme",
   "devDependencies": {
+    "babel-core": "^6.24.0",
+    "babel-loader": "^6.4.1",
+    "babel-preset-es2015": "^6.24.0",
     "webpack": "^2.3.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,12 +7,19 @@ module.exports = {
     libraryTarget: 'umd',
     library: 'streams-lib'
   },
-  // plugins: [
-  //   new webpack.optimize.UglifyJsPlugin({
-  //     compressor: {
-  //       screw_ie8: true,
-  //       warnings: false
-  //     }
-  //   })
-  // ]
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: 'babel-loader',
+        query: {
+          presets: ['es2015']
+        }
+      }
+    ]
+  },
+  resolve: {
+    extensions: [' ', '.js']
+  }
 };


### PR DESCRIPTION
The Streams spec reference implementation for Streams API is implemented in ES6 syntax. As PDF.js uses ES5.1 format, hence to make the Streams API reference implementation compatible with PDF.js, we have to port it to ES5.1.